### PR TITLE
Add support for `setupFiles` and `snapshotSerializers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The lists below are not comprehensive: feel free to [start a discussion](https:/
 - Jest function mocks: `jest.fn`, `jest.spyOn`
 - Inline and external snapshots
 - `--testNamePattern`/`-t`, to only run some specific tests
+- Jest config: `setupFiles`, `snapshotSerializers`
 
 ### Unsupported Jest features
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The lists below are not comprehensive: feel free to [start a discussion](https:/
 - Jest function mocks: `jest.fn`, `jest.spyOn`
 - Inline and external snapshots
 - `--testNamePattern`/`-t`, to only run some specific tests
-- Jest config: `setupFiles`, `snapshotSerializers`
+- Jest config options: `setupFiles`, `snapshotSerializers`
 
 ### Unsupported Jest features
 

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -44,7 +44,7 @@ export default async function ({
   }
 
   for (const snapshotSerializer of [...snapshotSerializers].reverse()) {
-    let { default: serializer } = await import(pathToFileURL(snapshotSerializer));
+    const { default: serializer } = await import(pathToFileURL(snapshotSerializer));
     snapshot.addSerializer(serializer);
   }
 

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -36,20 +36,15 @@ export default async function ({
 
   // https://github.com/facebook/jest/issues/11038
   for (const setupFile of setupFiles) {
-    const setup = await import(pathToFileURL(setupFile));
+    const { default: setup } = await import(pathToFileURL(setupFile));
 
-    if (setup && setup.default) {
-      await setup.default;
+    if (typeof setup === 'function') {
+      await setup();
     }
   }
 
-  for (const snapshotSerializer of snapshotSerializers) {
-    let serializer = await import(pathToFileURL(snapshotSerializer));
-
-    if (serializer && serializer.default) {
-      serializer = serializer.default;
-    }
-
+  for (const snapshotSerializer of [...snapshotSerializers].reverse()) {
+    let { default: serializer } = await import(pathToFileURL(snapshotSerializer));
     snapshot.addSerializer(serializer);
   }
 

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -32,6 +32,27 @@ export default async function ({
 }) {
   port.postMessage("start");
 
+  const {setupFiles, snapshotSerializers} = test.context.config;
+
+  // https://github.com/facebook/jest/issues/11038
+  for (const setupFile of setupFiles) {
+    const setup = await import(pathToFileURL(setupFile));
+
+    if (setup && setup.default) {
+      await setup.default;
+    }
+  }
+
+  for (const snapshotSerializer of snapshotSerializers) {
+    let serializer = await import(pathToFileURL(snapshotSerializer));
+
+    if (serializer && serializer.default) {
+      serializer = serializer.default;
+    }
+
+    snapshot.addSerializer(serializer);
+  }
+
   const testNamePatternRE =
     testNamePattern != null ? new RegExp(testNamePattern, "i") : null;
 


### PR DESCRIPTION
Prettier added these when using this module. 
https://github.com/prettier/prettier/tree/next/tests/config/jest-light-runner