### PR TITLE
feat: add coverage support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "yarn prettier . --ignore-unknown --check"
   },
   "dependencies": {
+    "collect-v8-coverage": "^1.0.1",
     "expect": "^27.5.1",
     "jest-circus": "^27.5.1",
     "jest-each": "^27.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,12 @@ export default class LightRunner {
   constructor(config) {
     this.#config = config;
 
+    const { collectCoverage, coverageProvider } = this.#config;
+
+    if (collectCoverage && coverageProvider !== "v8") {
+      throw new Error("Coverage needs v8 coverage provider");
+    }
+
     this.#piscina = new Piscina({
       filename: new URL("./worker-runner.js", import.meta.url).href,
       maxThreads: this.#config.maxWorkers,
@@ -31,7 +37,7 @@ export default class LightRunner {
    * @param {*} onFailure
    */
   runTests(tests, watcher, onStart, onResult, onFailure) {
-    const { updateSnapshot, testNamePattern } = this.#config;
+    const { updateSnapshot, testNamePattern, collectCoverage } = this.#config;
 
     return Promise.all(
       tests.map(test => {
@@ -41,7 +47,13 @@ export default class LightRunner {
 
         return this.#piscina
           .run(
-            { test, updateSnapshot, testNamePattern, port: mc.port1 },
+            {
+              test,
+              updateSnapshot,
+              testNamePattern,
+              port: mc.port1,
+              collectCoverage,
+            },
             { transferList: [mc.port1] }
           )
           .then(

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -5,6 +5,7 @@ import snapshot from "jest-snapshot";
 import expect from "expect";
 import * as circus from "jest-circus";
 import { inspect } from "util";
+import { CoverageInstrumenter } from "collect-v8-coverage";
 
 import "./global-setup.js";
 
@@ -29,6 +30,7 @@ export default async function ({
   updateSnapshot,
   testNamePattern,
   port,
+  collectCoverage,
 }) {
   port.postMessage("start");
 
@@ -58,6 +60,14 @@ export default async function ({
   /** @type {Array<InternalTestResult>} */
   const results = [];
 
+  let instrumenter = null;
+
+  if (collectCoverage) {
+    instrumenter = new CoverageInstrumenter();
+
+    await instrumenter.startInstrumenting();
+  }
+
   const { tests, hasFocusedTests } = await loadTests(test.path);
 
   const snapshotState = new snapshot.SnapshotState(
@@ -70,6 +80,26 @@ export default async function ({
   await runTestBlock(tests, hasFocusedTests, testNamePatternRE, results, stats);
   stats.end = performance.now();
 
+  let v8Coverage = undefined;
+
+  if (instrumenter) {
+    v8Coverage = await instrumenter.stopInstrumenting();
+    v8Coverage = v8Coverage
+      .filter(res => res.url.startsWith("file://"))
+      .map(res => ({ ...res, url: fileURLToPath(res.url) }))
+        .filter(res => !res.url.includes('node_modules'))
+      // .filter(
+      //     res =>
+      //         // TODO: will this work on windows? It might be better if `shouldInstrument` deals with it anyways
+      //         res.url.startsWith(this._config.rootDir) &&
+      //         this._fileTransforms.has(res.url) &&
+      //         shouldInstrument(res.url, this._coverageOptions, this._config),
+      // )
+      .map(result => {
+        return { result };
+      });
+  }
+
   snapshotState._inlineSnapshots.forEach(({ frame }) => {
     // When using native ESM, errors have a URL location.
     // Jest expects paths.
@@ -77,7 +107,7 @@ export default async function ({
   });
   snapshotState.save();
 
-  return toTestResult(stats, results, test);
+  return toTestResult(stats, results, test, v8Coverage);
 }
 
 async function loadTests(testFile) {
@@ -211,9 +241,10 @@ function callAsync(fn) {
  * @param {Stats} stats
  * @param {Array<InternalTestResult>} tests
  * @param {import("@jest/test-result").Test} testInput
+ * @param {import("@jest/test-result").V8CoverageResult} v8Coverage
  * @returns {import("@jest/test-result").TestResult}
  */
-function toTestResult(stats, tests, { path, context }) {
+function toTestResult(stats, tests, { path, context }, v8Coverage) {
   const { start, end } = stats;
   const runtime = end - start;
 
@@ -260,6 +291,7 @@ function toTestResult(stats, tests, { path, context }) {
         title: test.title,
       };
     }),
+    v8Coverage,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,7 +993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"collect-v8-coverage@npm:^1.0.0":
+"collect-v8-coverage@npm:^1.0.0, collect-v8-coverage@npm:^1.0.1":
   version: 1.0.1
   resolution: "collect-v8-coverage@npm:1.0.1"
   checksum: 4efe0a1fccd517b65478a2364b33dadd0a43fc92a56f59aaece9b6186fe5177b2de471253587de7c91516f07c7268c2f6770b6cbcffc0e0ece353b766ec87e55
@@ -1672,6 +1672,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-light-runner@workspace:."
   dependencies:
+    collect-v8-coverage: ^1.0.1
     expect: ^27.5.1
     jest-circus: ^27.5.1
     jest-each: ^27.5.1


### PR DESCRIPTION
Note that this doesn't really work - the commented out `filter` needs to be there in some way.

However, copying this over into prettier seems to work fine.

<img width="1899" alt="image" src="https://user-images.githubusercontent.com/1404810/161988017-833f985e-25bd-4353-bc5c-ad89c83baa08.png">


Fixes #6.