### PR TITLE
Add support for `jest.clearAllMocks` and `jest.resetAllMocks`

### DIFF
--- a/src/global-setup.js
+++ b/src/global-setup.js
@@ -13,6 +13,8 @@ expect.extend({
   toThrowErrorMatchingSnapshot: snapshot.toThrowErrorMatchingSnapshot,
 });
 
+const jestMock = new mock.ModuleMocker(globalThis);
+
 globalThis.expect = expect;
 globalThis.test = circus.test;
 globalThis.it = circus.it;
@@ -22,6 +24,8 @@ globalThis.afterAll = circus.afterAll;
 globalThis.beforeEach = circus.beforeEach;
 globalThis.afterEach = circus.afterEach;
 globalThis.jest = {
-  fn: mock.fn,
-  spyOn: mock.spyOn,
+  fn: jestMock.fn.bind(jestMock),
+  spyOn: jestMock.spyOn.bind(jestMock),
+  clearAllMocks: jestMock.clearAllMocks.bind(jestMock),
+  resetAllMocks: jestMock.resetAllMocks.bind(jestMock),
 };

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -180,7 +180,12 @@ async function runHooks(hook, block, results, stats, ancestors, runInParents) {
     if (type === hook) {
       await callAsync(fn).catch(error => {
         stats.failures++;
-        results.push({ ancestors, title: `(${hook})`, errors:[error], skipped: false });
+        results.push({
+          ancestors,
+          title: `(${hook})`,
+          errors: [error],
+          skipped: false,
+        });
       });
     }
   }

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -180,7 +180,7 @@ async function runHooks(hook, block, results, stats, ancestors, runInParents) {
     if (type === hook) {
       await callAsync(fn).catch(error => {
         stats.failures++;
-        results.push({ ancestors, title: `(${hook})`, error, skipped: false });
+        results.push({ ancestors, title: `(${hook})`, errors:[error], skipped: false });
       });
     }
   }


### PR DESCRIPTION
This PR aims to add support for `jest.clearAllMocks` and `jest.resetAllMocks`.
Fixes #18 

- [x] Show proper error message instead of the existing error log `TypeError: Cannot read properties of undefined (reading 'length')`. Now shows `TypeError: jest.clearAllMocks is not a function`. Fixed in 14336c3d42e23705d77778e7a198ba12121a8905
- [x] Support `jest.clearAllMocks`
- [x] Support `jest.resetAllMocks`
- [x] Tested

### Need a small help with last 2 tasks
Thanks for [hinting me](https://github.com/nicolo-ribaudo/jest-light-runner/issues/18#issuecomment-1101449323) where to change. I tried this, and I'm facing a small issue.

I could have done like this in the `global.setup.js`:
```js
// excerpt
globalThis.jest = {
  fn: mock.fn,
  spyOn: mock.spyOn,
  clearAllMocks: mock.JestMock.clearAllMocks.bind(mock.JestMock),
  // ...
};
```
But the `jest-mock` package seem not exporting the `JestMock` instance. So I can't do `mock.JestMock.<thing>`.
https://github.com/facebook/jest/blob/d2f3dc694d72c0208f47fc2e2ca101e26a9a6d68/packages/jest-mock/src/index.ts#L1239-L1243

Could someone help?