### PR TITLE
Support `snapshotFormat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The lists below are not comprehensive: feel free to [start a discussion](https:/
 - Jest function mocks: `jest.fn`, `jest.spyOn`, `jest.clearAllMocks`, `jest.resetAllMocks`
 - Inline and external snapshots
 - Jest cli options: `--testNamePattern`/`-t`, `--maxWorkers`, `--runInBand`
-- Jest config options: `setupFiles`, `snapshotSerializers`, `maxWorkers`
+- Jest config options: `setupFiles`, `snapshotSerializers`, `maxWorkers`, `snapshotFormat`
 
 ### Unsupported Jest features
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     ".": "./src/index.js"
   },
   "scripts": {
-    "format": "yarn prettier . --ignore-unknown --write",
-    "lint": "yarn prettier . --ignore-unknown --check"
+    "format": "yarn prettier . --write",
+    "lint": "yarn prettier . --check"
   },
   "dependencies": {
     "expect": "^27.5.1",

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -33,7 +33,8 @@ export default async function ({
 }) {
   port.postMessage("start");
 
-  const { setupFiles, snapshotSerializers } = test.context.config;
+  const { setupFiles, snapshotSerializers, snapshotFormat } =
+    test.context.config;
 
   // https://github.com/facebook/jest/issues/11038
   for (const setupFile of setupFiles) {
@@ -63,7 +64,7 @@ export default async function ({
 
   const snapshotState = new snapshot.SnapshotState(
     `${path.dirname(test.path)}/__snapshots__/${path.basename(test.path)}.snap`,
-    { prettierPath: "prettier", updateSnapshot }
+    { prettierPath: "prettier", updateSnapshot, snapshotFormat }
   );
   expect.setState({ snapshotState });
 


### PR DESCRIPTION
Prettier added this option in https://github.com/prettier/prettier/pull/12612 by @SimenB 

(Maybe Babel can also use it?)

I've tested locally, it works.

//cc @SimenB 