### PR TITLE
Support `expect.addSnapshotSerializer()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "yarn prettier . --check"
   },
   "dependencies": {
-    "expect": "^28.0.1",
+    "@jest/expect": "^28.0.2",
     "jest-circus": "^28.0.0",
     "jest-each": "^28.0.0",
     "jest-mock": "^28.0.0",

--- a/src/global-setup.js
+++ b/src/global-setup.js
@@ -12,6 +12,7 @@ expect.extend({
     snapshot.toThrowErrorMatchingInlineSnapshot,
   toThrowErrorMatchingSnapshot: snapshot.toThrowErrorMatchingSnapshot,
 });
+expect.addSnapshotSerializer = snapshot.addSerializer;
 
 const jestMock = new mock.ModuleMocker(globalThis);
 

--- a/src/global-setup.js
+++ b/src/global-setup.js
@@ -1,18 +1,9 @@
 /* eslint-disable import/extensions */
 
 import mock from "jest-mock";
-import { expect } from "expect";
+import { jestExpect as expect } from "@jest/expect";
 import snapshot from "jest-snapshot";
 import * as circus from "jest-circus";
-
-expect.extend({
-  toMatchInlineSnapshot: snapshot.toMatchInlineSnapshot,
-  toMatchSnapshot: snapshot.toMatchSnapshot,
-  toThrowErrorMatchingInlineSnapshot:
-    snapshot.toThrowErrorMatchingInlineSnapshot,
-  toThrowErrorMatchingSnapshot: snapshot.toThrowErrorMatchingSnapshot,
-});
-expect.addSnapshotSerializer = snapshot.addSerializer;
 
 const jestMock = new mock.ModuleMocker(globalThis);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/expect-utils@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "@jest/expect-utils@npm:28.0.2"
+  dependencies:
+    jest-get-type: ^28.0.2
+  checksum: 09cfff4d9c614c6c5181cb06908ed9524d087e4ff4552401116fe773fc51f45097c7c1bd7061ce9ae0906be012d15bb165639d4b0b5565e951e0cb75ad25fa92
+  languageName: node
+  linkType: hard
+
 "@jest/expect@npm:^28.0.0":
   version: 28.0.0
   resolution: "@jest/expect@npm:28.0.0"
@@ -459,6 +468,16 @@ __metadata:
     expect: ^28.0.0
     jest-snapshot: ^28.0.0
   checksum: 054b6233007a462ad6f4600f0d7d6df245ef8f5a559237eb9efcc6ea3d9f7833ea620fad7b65a21ae5a856e6f9a57aaa266b7e85e1b00739d40eca901123dc71
+  languageName: node
+  linkType: hard
+
+"@jest/expect@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "@jest/expect@npm:28.0.2"
+  dependencies:
+    expect: ^28.0.2
+    jest-snapshot: ^28.0.2
+  checksum: 91b5f2fdfc66a7125fec02e94db4e8f113d4ab5b35f9db7596b5dffcd1ca6440bff29bbdfba6af41b08c0c9053838db5197bec110f0125d33b00ea2fe4029963
   languageName: node
   linkType: hard
 
@@ -493,6 +512,15 @@ __metadata:
   dependencies:
     "@sinclair/typebox": ^0.23.3
   checksum: 4133d84a7fbb428b9d847aeb218fbaf75c6c4096659b8514868dcc31b510ecba13748309f9453bbd600e542b21f323a8e53a6caec9e491ce5bbdfced0ad088ae
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "@jest/schemas@npm:28.0.2"
+  dependencies:
+    "@sinclair/typebox": ^0.23.3
+  checksum: 6a177e97b112c99f377697fe803a34f4489b92cd07949876250c69edc9029c7cbda771fcbb03caebd20ffbcfa89b9c22b4dc9d1e9a7fbc9873185459b48ba780
   languageName: node
   linkType: hard
 
@@ -542,6 +570,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/transform@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "@jest/transform@npm:28.0.2"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/types": ^28.0.2
+    "@jridgewell/trace-mapping": ^0.3.7
+    babel-plugin-istanbul: ^6.1.1
+    chalk: ^4.0.0
+    convert-source-map: ^1.4.0
+    fast-json-stable-stringify: ^2.0.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^28.0.2
+    jest-regex-util: ^28.0.2
+    jest-util: ^28.0.2
+    micromatch: ^4.0.4
+    pirates: ^4.0.4
+    slash: ^3.0.0
+    write-file-atomic: ^4.0.1
+  checksum: d12893ec646809f41160f28110103f28ce4a82dc7d10265cca31807242d1d4506e1139f984ebf6044ff3c12d932cf3718fd5c9b39728a3732c7268ec0f2eec18
+  languageName: node
+  linkType: hard
+
 "@jest/types@npm:^28.0.0, @jest/types@npm:^28.0.1":
   version: 28.0.1
   resolution: "@jest/types@npm:28.0.1"
@@ -553,6 +604,20 @@ __metadata:
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
   checksum: e0796f6982560d6f58bc028affb451746d163d2b4467838134eab827501f839e60a4a787e903b804c9b15cd6efeb186cb3d3d79be49ae60c5b8990cc1d773db7
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "@jest/types@npm:28.0.2"
+  dependencies:
+    "@jest/schemas": ^28.0.2
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^17.0.8
+    chalk: ^4.0.0
+  checksum: ffb166ed4a90aaeb8cdf04928f15cda8ac29076cb88963d7cfde4740daa5649d689f713b3f815ca7db49c01eda3a932b1d904d76877a5f3b5837a0a6fb727379
   languageName: node
   linkType: hard
 
@@ -1141,6 +1206,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff-sequences@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "diff-sequences@npm:28.0.2"
+  checksum: 482360a8ec93333ea61bc93a800a1bee37c943b94a48fa1597825076adcad24620b44a0d3aa8f3d190584a4156c4b3315028453ca33e1174001fae3cdaa7f8f8
+  languageName: node
+  linkType: hard
+
 "electron-to-chromium@npm:^1.4.84":
   version: 1.4.95
   resolution: "electron-to-chromium@npm:1.4.95"
@@ -1233,7 +1305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^28.0.0, expect@npm:^28.0.1":
+"expect@npm:^28.0.0":
   version: 28.0.1
   resolution: "expect@npm:28.0.1"
   dependencies:
@@ -1243,6 +1315,19 @@ __metadata:
     jest-message-util: ^28.0.1
     jest-util: ^28.0.1
   checksum: cf7aadadc821185aab5215c75173c912b3ac1be75b972112320a2f11ad59caf98459cc6c3e1fce301d4d74e01bca24eb8a3a16a770f52b50ad93beeb11908262
+  languageName: node
+  linkType: hard
+
+"expect@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "expect@npm:28.0.2"
+  dependencies:
+    "@jest/expect-utils": ^28.0.2
+    jest-get-type: ^28.0.2
+    jest-matcher-utils: ^28.0.2
+    jest-message-util: ^28.0.2
+    jest-util: ^28.0.2
+  checksum: 5b638e30da6c07df46d915da5268c9dcd9d942c635b351d34b691815d35743771a1d7014e3ba11aef6d4da19f5578e1920b1711396cf1f65241e6b8571a3ae3f
   languageName: node
   linkType: hard
 
@@ -1644,6 +1729,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-diff@npm:28.0.2"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^28.0.2
+    jest-get-type: ^28.0.2
+    pretty-format: ^28.0.2
+  checksum: 71601b7a20840da9b4306d22c0d88a61116f169036f7261a5f6edf9ec8800e1dfe2cc854a9b5b628bc84a2952cd5a23e5f88bda4a6979fb1dc3b863b2d9ac080
+  languageName: node
+  linkType: hard
+
 "jest-each@npm:^28.0.0":
   version: 28.0.0
   resolution: "jest-each@npm:28.0.0"
@@ -1661,6 +1758,13 @@ __metadata:
   version: 28.0.0
   resolution: "jest-get-type@npm:28.0.0"
   checksum: 9ed94d148a0ceb7cd2ff0cc22c7067f992fbcbbf0cea3183afd26f20a848c4731c854127c18b2a3f127efd43c31c42d04fdbdf72c02314e22da89dc7c842b185
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-get-type@npm:28.0.2"
+  checksum: 5281d7c89bc8156605f6d15784f45074f4548501195c26e9b188742768f72d40948252d13230ea905b5349038865a1a8eeff0e614cc530ff289dfc41fe843abd
   languageName: node
   linkType: hard
 
@@ -1687,11 +1791,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-haste-map@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-haste-map@npm:28.0.2"
+  dependencies:
+    "@jest/types": ^28.0.2
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    anymatch: ^3.0.3
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.9
+    jest-regex-util: ^28.0.2
+    jest-util: ^28.0.2
+    jest-worker: ^28.0.2
+    micromatch: ^4.0.4
+    walker: ^1.0.7
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: c1e9cb964dcfc6955272447b728ba8136fc1ec3ec41ab1e551f6c19c93c558c840278cf41b198410fe2cbb2ae7764a27f8566c226a096b5e896a0f7113f87a39
+  languageName: node
+  linkType: hard
+
 "jest-light-runner@workspace:.":
   version: 0.0.0-use.local
   resolution: "jest-light-runner@workspace:."
   dependencies:
-    expect: ^28.0.1
+    "@jest/expect": ^28.0.2
     jest-circus: ^28.0.0
     jest-each: ^28.0.0
     jest-mock: ^28.0.0
@@ -1716,6 +1843,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-matcher-utils@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-matcher-utils@npm:28.0.2"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^28.0.2
+    jest-get-type: ^28.0.2
+    pretty-format: ^28.0.2
+  checksum: 3c6fab0746d4f034de681c853171a7ff5cf72226c54257225c0199762667c38457aa07f0ce61a007e94c87ac712f704535a250b5b552147b1ec521dcdea1ee89
+  languageName: node
+  linkType: hard
+
 "jest-message-util@npm:^28.0.0, jest-message-util@npm:^28.0.1":
   version: 28.0.1
   resolution: "jest-message-util@npm:28.0.1"
@@ -1730,6 +1869,23 @@ __metadata:
     slash: ^3.0.0
     stack-utils: ^2.0.3
   checksum: c504e5384f3f5556d7513111b0600618c8fc0fcd34c69414e6b56bff2731fd916e94d8e63571669f5d6ea3fea2f0eb8ee45b8d329b984f533687c135742f21d3
+  languageName: node
+  linkType: hard
+
+"jest-message-util@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-message-util@npm:28.0.2"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^28.0.2
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    micromatch: ^4.0.4
+    pretty-format: ^28.0.2
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 61a180667fe5c00551b1e0cb8ee09a4844bbdebb6940e3810aad5fac9bc647862572dedf20c8cf77b9643679d4947b0452d8e3afcef7e3b4139997447384facc
   languageName: node
   linkType: hard
 
@@ -1759,6 +1915,13 @@ __metadata:
   version: 28.0.0
   resolution: "jest-regex-util@npm:28.0.0"
   checksum: 919be9931accf195258e40118b1817cb472b2dfb63f58e8a193f8d4a8964a4cd24ac2f3878fb3db551f806e6948150b7aa20b8442a6db2c5b71e910c430c4570
+  languageName: node
+  linkType: hard
+
+"jest-regex-util@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-regex-util@npm:28.0.2"
+  checksum: 0ea8c5c82ec88bc85e273c0ec82e0c0f35f7a1e2d055070e50f0cc2a2177f848eec55f73e37ae0d045c3db5014c42b2f90ac62c1ab3fdb354d2abd66a9e08add
   languageName: node
   linkType: hard
 
@@ -1840,6 +2003,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-snapshot@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-snapshot@npm:28.0.2"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@babel/generator": ^7.7.2
+    "@babel/plugin-syntax-typescript": ^7.7.2
+    "@babel/traverse": ^7.7.2
+    "@babel/types": ^7.3.3
+    "@jest/expect-utils": ^28.0.2
+    "@jest/transform": ^28.0.2
+    "@jest/types": ^28.0.2
+    "@types/babel__traverse": ^7.0.6
+    "@types/prettier": ^2.1.5
+    babel-preset-current-node-syntax: ^1.0.0
+    chalk: ^4.0.0
+    expect: ^28.0.2
+    graceful-fs: ^4.2.9
+    jest-diff: ^28.0.2
+    jest-get-type: ^28.0.2
+    jest-haste-map: ^28.0.2
+    jest-matcher-utils: ^28.0.2
+    jest-message-util: ^28.0.2
+    jest-util: ^28.0.2
+    natural-compare: ^1.4.0
+    pretty-format: ^28.0.2
+    semver: ^7.3.5
+  checksum: 62383b8c77d1c643694c7ef1d1455e43ba63dcd16ce77ed3c3f7a40e834db348a487989864da81878009944a2d3f6e9440f9883c30da1908e6303d3fdbf17942
+  languageName: node
+  linkType: hard
+
 "jest-util@npm:^28.0.0, jest-util@npm:^28.0.1":
   version: 28.0.1
   resolution: "jest-util@npm:28.0.1"
@@ -1851,6 +2045,20 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: b5a775aa6cd5510f4982ce0fa25096c0bb8ce08369a2d1368fd8b8d4d540cf933e0b9bcac5663131a4dfbe8c266f36fe109e06bc3f9dab45c5588dcf7b68c37a
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-util@npm:28.0.2"
+  dependencies:
+    "@jest/types": ^28.0.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  checksum: 3e50e73c93c36ebc378c22b47ba02bf0bbe093266553956a8186e2670080c125d9419b1efeadb4ce59561c28d2df9af15fa19e1fdb9c0b4c3a3fe7c2f0af51a7
   languageName: node
   linkType: hard
 
@@ -1876,6 +2084,17 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: 68875e7aefbd8bb4ee85e61a5b6d3d679067683a2b857c0c58063f7b12789aa871eba29a8c7eb4f3bb2ff4f0280668ca46206e9654c3d346927ef11176576d0e
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "jest-worker@npm:28.0.2"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: c60ee11920fe84390ff8ffdd3bf001e25de718004c5c9c709dd080671a7cd88760d8b894cc5e15caa86dac478ae5d0a360c44f4bac5b86ed7e06c24a5b2ea83d
   languageName: node
   linkType: hard
 
@@ -2366,6 +2585,18 @@ __metadata:
     ansi-styles: ^5.0.0
     react-is: ^18.0.0
   checksum: d4b861d5aff94a65ffbf386f312db494f48c9529017e13b2279866fabbd8abdd86acb4e8150d19de07c5d8d46919fcf904e6fa8b034574cdd78bf5f8da0f2ad4
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^28.0.2":
+  version: 28.0.2
+  resolution: "pretty-format@npm:28.0.2"
+  dependencies:
+    "@jest/schemas": ^28.0.2
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: 785ce1928f17de0e250496e0413fb9ad883a4d5ebb6e9b346f3094140eb2af096770de8b6d3b8adffc0e9692d031d62a603c851e9f3b81b2670a086ad256ad77
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,15 +443,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect-utils@npm:^28.0.0, @jest/expect-utils@npm:^28.0.1":
-  version: 28.0.1
-  resolution: "@jest/expect-utils@npm:28.0.1"
-  dependencies:
-    jest-get-type: ^28.0.0
-  checksum: 504682033a99acae53c27485f193aadf39a040776fda71986736d7b22407e1f71bccd1d875632153ef04448b59250d6a98c5e9c658629ae090ab7b04fedd613f
-  languageName: node
-  linkType: hard
-
 "@jest/expect-utils@npm:^28.0.2":
   version: 28.0.2
   resolution: "@jest/expect-utils@npm:28.0.2"
@@ -461,17 +452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "@jest/expect@npm:28.0.0"
-  dependencies:
-    expect: ^28.0.0
-    jest-snapshot: ^28.0.0
-  checksum: 054b6233007a462ad6f4600f0d7d6df245ef8f5a559237eb9efcc6ea3d9f7833ea620fad7b65a21ae5a856e6f9a57aaa266b7e85e1b00739d40eca901123dc71
-  languageName: node
-  linkType: hard
-
-"@jest/expect@npm:^28.0.2":
+"@jest/expect@npm:^28.0.0, @jest/expect@npm:^28.0.2":
   version: 28.0.2
   resolution: "@jest/expect@npm:28.0.2"
   dependencies:
@@ -503,15 +484,6 @@ __metadata:
     "@jest/expect": ^28.0.0
     "@jest/types": ^28.0.0
   checksum: b9d735a15985f3fcf58feaf8329528aa9dfc40e7f1f2b16a4db3b4aea6bac1a966be0275352e30908f3cc5dc250d5a3b58e3d79296a34f4c79e0a9ff7e8f0649
-  languageName: node
-  linkType: hard
-
-"@jest/schemas@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "@jest/schemas@npm:28.0.0"
-  dependencies:
-    "@sinclair/typebox": ^0.23.3
-  checksum: 4133d84a7fbb428b9d847aeb218fbaf75c6c4096659b8514868dcc31b510ecba13748309f9453bbd600e542b21f323a8e53a6caec9e491ce5bbdfced0ad088ae
   languageName: node
   linkType: hard
 
@@ -547,30 +519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "@jest/transform@npm:28.0.0"
-  dependencies:
-    "@babel/core": ^7.11.6
-    "@jest/types": ^28.0.0
-    "@jridgewell/trace-mapping": ^0.3.7
-    babel-plugin-istanbul: ^6.1.1
-    chalk: ^4.0.0
-    convert-source-map: ^1.4.0
-    fast-json-stable-stringify: ^2.0.0
-    graceful-fs: ^4.2.9
-    jest-haste-map: ^28.0.0
-    jest-regex-util: ^28.0.0
-    jest-util: ^28.0.0
-    micromatch: ^4.0.4
-    pirates: ^4.0.4
-    slash: ^3.0.0
-    write-file-atomic: ^4.0.1
-  checksum: 217bbba166156cfd8f18984933ae4ad7af20505812e17e1ee923f428ec9af867e6c44758d2809fac14b60293a3b970cdc2afe48ae37b299a25943fa02496a5b0
-  languageName: node
-  linkType: hard
-
-"@jest/transform@npm:^28.0.2":
+"@jest/transform@npm:^28.0.0, @jest/transform@npm:^28.0.2":
   version: 28.0.2
   resolution: "@jest/transform@npm:28.0.2"
   dependencies:
@@ -593,21 +542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^28.0.0, @jest/types@npm:^28.0.1":
-  version: 28.0.1
-  resolution: "@jest/types@npm:28.0.1"
-  dependencies:
-    "@jest/schemas": ^28.0.0
-    "@types/istanbul-lib-coverage": ^2.0.0
-    "@types/istanbul-reports": ^3.0.0
-    "@types/node": "*"
-    "@types/yargs": ^17.0.8
-    chalk: ^4.0.0
-  checksum: e0796f6982560d6f58bc028affb451746d163d2b4467838134eab827501f839e60a4a787e903b804c9b15cd6efeb186cb3d3d79be49ae60c5b8990cc1d773db7
-  languageName: node
-  linkType: hard
-
-"@jest/types@npm:^28.0.2":
+"@jest/types@npm:^28.0.0, @jest/types@npm:^28.0.2":
   version: 28.0.2
   resolution: "@jest/types@npm:28.0.2"
   dependencies:
@@ -1199,13 +1134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff-sequences@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "diff-sequences@npm:28.0.0"
-  checksum: 8e6aab76bec1508ed469d5c24872dcbb358dd28b0d17f1d1b40f4e7342e1a484b6690ce4eb80b4ba69d56938561410d9c5fc272a856adf3b24e4f42c6a11ad77
-  languageName: node
-  linkType: hard
-
 "diff-sequences@npm:^28.0.2":
   version: 28.0.2
   resolution: "diff-sequences@npm:28.0.2"
@@ -1302,19 +1230,6 @@ __metadata:
     signal-exit: ^3.0.3
     strip-final-newline: ^2.0.0
   checksum: fba9022c8c8c15ed862847e94c252b3d946036d7547af310e344a527e59021fd8b6bb0723883ea87044dc4f0201f949046993124a42ccb0855cae5bf8c786343
-  languageName: node
-  linkType: hard
-
-"expect@npm:^28.0.0":
-  version: 28.0.1
-  resolution: "expect@npm:28.0.1"
-  dependencies:
-    "@jest/expect-utils": ^28.0.1
-    jest-get-type: ^28.0.0
-    jest-matcher-utils: ^28.0.1
-    jest-message-util: ^28.0.1
-    jest-util: ^28.0.1
-  checksum: cf7aadadc821185aab5215c75173c912b3ac1be75b972112320a2f11ad59caf98459cc6c3e1fce301d4d74e01bca24eb8a3a16a770f52b50ad93beeb11908262
   languageName: node
   linkType: hard
 
@@ -1717,18 +1632,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^28.0.0, jest-diff@npm:^28.0.1":
-  version: 28.0.1
-  resolution: "jest-diff@npm:28.0.1"
-  dependencies:
-    chalk: ^4.0.0
-    diff-sequences: ^28.0.0
-    jest-get-type: ^28.0.0
-    pretty-format: ^28.0.1
-  checksum: a91e7f298601f9ea9f8816560664bcbef304fc83a6b90a1547d020605d844dbe4590d8be38bfe8b532179eaa09f47978472fabcf07b722223eb6a1ae9d81033a
-  languageName: node
-  linkType: hard
-
 "jest-diff@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-diff@npm:28.0.2"
@@ -1754,44 +1657,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-get-type@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "jest-get-type@npm:28.0.0"
-  checksum: 9ed94d148a0ceb7cd2ff0cc22c7067f992fbcbbf0cea3183afd26f20a848c4731c854127c18b2a3f127efd43c31c42d04fdbdf72c02314e22da89dc7c842b185
-  languageName: node
-  linkType: hard
-
-"jest-get-type@npm:^28.0.2":
+"jest-get-type@npm:^28.0.0, jest-get-type@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-get-type@npm:28.0.2"
   checksum: 5281d7c89bc8156605f6d15784f45074f4548501195c26e9b188742768f72d40948252d13230ea905b5349038865a1a8eeff0e614cc530ff289dfc41fe843abd
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "jest-haste-map@npm:28.0.0"
-  dependencies:
-    "@jest/types": ^28.0.0
-    "@types/graceful-fs": ^4.1.3
-    "@types/node": "*"
-    anymatch: ^3.0.3
-    fb-watchman: ^2.0.0
-    fsevents: ^2.3.2
-    graceful-fs: ^4.2.9
-    jest-regex-util: ^28.0.0
-    jest-util: ^28.0.0
-    jest-worker: ^28.0.0
-    micromatch: ^4.0.4
-    walker: ^1.0.7
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: 32d2a33599313969966017e58ce95fbaabf880d7fbc01d73810ac00fcc34dba0006e5c280acfb1e2bb7c27d1cd09288272e2e4afb69a38146283e55668f835b2
-  languageName: node
-  linkType: hard
-
-"jest-haste-map@npm:^28.0.2":
+"jest-haste-map@npm:^28.0.0, jest-haste-map@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-haste-map@npm:28.0.2"
   dependencies:
@@ -1831,19 +1704,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"jest-matcher-utils@npm:^28.0.0, jest-matcher-utils@npm:^28.0.1":
-  version: 28.0.1
-  resolution: "jest-matcher-utils@npm:28.0.1"
-  dependencies:
-    chalk: ^4.0.0
-    jest-diff: ^28.0.1
-    jest-get-type: ^28.0.0
-    pretty-format: ^28.0.1
-  checksum: f8179eccd36533724d73d6bdb0925141d672a8dc08ea30ecb6befc6e6dfb6d6e3a4f785d275880cae9d213ed4af9a90cff6c1b9b91716151ea6d6bb6fe2bfd56
-  languageName: node
-  linkType: hard
-
-"jest-matcher-utils@npm:^28.0.2":
+"jest-matcher-utils@npm:^28.0.0, jest-matcher-utils@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-matcher-utils@npm:28.0.2"
   dependencies:
@@ -1855,24 +1716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-message-util@npm:^28.0.0, jest-message-util@npm:^28.0.1":
-  version: 28.0.1
-  resolution: "jest-message-util@npm:28.0.1"
-  dependencies:
-    "@babel/code-frame": ^7.12.13
-    "@jest/types": ^28.0.1
-    "@types/stack-utils": ^2.0.0
-    chalk: ^4.0.0
-    graceful-fs: ^4.2.9
-    micromatch: ^4.0.4
-    pretty-format: ^28.0.1
-    slash: ^3.0.0
-    stack-utils: ^2.0.3
-  checksum: c504e5384f3f5556d7513111b0600618c8fc0fcd34c69414e6b56bff2731fd916e94d8e63571669f5d6ea3fea2f0eb8ee45b8d329b984f533687c135742f21d3
-  languageName: node
-  linkType: hard
-
-"jest-message-util@npm:^28.0.2":
+"jest-message-util@npm:^28.0.0, jest-message-util@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-message-util@npm:28.0.2"
   dependencies:
@@ -1911,14 +1755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-regex-util@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "jest-regex-util@npm:28.0.0"
-  checksum: 919be9931accf195258e40118b1817cb472b2dfb63f58e8a193f8d4a8964a4cd24ac2f3878fb3db551f806e6948150b7aa20b8442a6db2c5b71e910c430c4570
-  languageName: node
-  linkType: hard
-
-"jest-regex-util@npm:^28.0.2":
+"jest-regex-util@npm:^28.0.0, jest-regex-util@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-regex-util@npm:28.0.2"
   checksum: 0ea8c5c82ec88bc85e273c0ec82e0c0f35f7a1e2d055070e50f0cc2a2177f848eec55f73e37ae0d045c3db5014c42b2f90ac62c1ab3fdb354d2abd66a9e08add
@@ -1972,38 +1809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "jest-snapshot@npm:28.0.0"
-  dependencies:
-    "@babel/core": ^7.11.6
-    "@babel/generator": ^7.7.2
-    "@babel/plugin-syntax-typescript": ^7.7.2
-    "@babel/traverse": ^7.7.2
-    "@babel/types": ^7.3.3
-    "@jest/expect-utils": ^28.0.0
-    "@jest/transform": ^28.0.0
-    "@jest/types": ^28.0.0
-    "@types/babel__traverse": ^7.0.6
-    "@types/prettier": ^2.1.5
-    babel-preset-current-node-syntax: ^1.0.0
-    chalk: ^4.0.0
-    expect: ^28.0.0
-    graceful-fs: ^4.2.9
-    jest-diff: ^28.0.0
-    jest-get-type: ^28.0.0
-    jest-haste-map: ^28.0.0
-    jest-matcher-utils: ^28.0.0
-    jest-message-util: ^28.0.0
-    jest-util: ^28.0.0
-    natural-compare: ^1.4.0
-    pretty-format: ^28.0.0
-    semver: ^7.3.5
-  checksum: fca954bbb22881b7b72495371705325ee9ba9296ab060f07e880bdb45a60dab2b8f2613664d44abc0fa76bf1b9dce577edea9f4a377bbef7924a5ed248601947
-  languageName: node
-  linkType: hard
-
-"jest-snapshot@npm:^28.0.2":
+"jest-snapshot@npm:^28.0.0, jest-snapshot@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-snapshot@npm:28.0.2"
   dependencies:
@@ -2034,21 +1840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^28.0.0, jest-util@npm:^28.0.1":
-  version: 28.0.1
-  resolution: "jest-util@npm:28.0.1"
-  dependencies:
-    "@jest/types": ^28.0.1
-    "@types/node": "*"
-    chalk: ^4.0.0
-    ci-info: ^3.2.0
-    graceful-fs: ^4.2.9
-    picomatch: ^2.2.3
-  checksum: b5a775aa6cd5510f4982ce0fa25096c0bb8ce08369a2d1368fd8b8d4d540cf933e0b9bcac5663131a4dfbe8c266f36fe109e06bc3f9dab45c5588dcf7b68c37a
-  languageName: node
-  linkType: hard
-
-"jest-util@npm:^28.0.2":
+"jest-util@npm:^28.0.0, jest-util@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-util@npm:28.0.2"
   dependencies:
@@ -2073,17 +1865,6 @@ __metadata:
     leven: ^3.1.0
     pretty-format: ^28.0.0
   checksum: fd6ea3de6c634fa90e0f8f9f4e24164a8850fb1df3cab9b0f089b6e262b1e12709f812b299215fd54c4bce59fe1b30e4d1350fa8e1e7d3abb688fd11b7e22717
-  languageName: node
-  linkType: hard
-
-"jest-worker@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "jest-worker@npm:28.0.0"
-  dependencies:
-    "@types/node": "*"
-    merge-stream: ^2.0.0
-    supports-color: ^8.0.0
-  checksum: 68875e7aefbd8bb4ee85e61a5b6d3d679067683a2b857c0c58063f7b12789aa871eba29a8c7eb4f3bb2ff4f0280668ca46206e9654c3d346927ef11176576d0e
   languageName: node
   linkType: hard
 
@@ -2576,19 +2357,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^28.0.0, pretty-format@npm:^28.0.1":
-  version: 28.0.1
-  resolution: "pretty-format@npm:28.0.1"
-  dependencies:
-    "@jest/schemas": ^28.0.0
-    ansi-regex: ^5.0.1
-    ansi-styles: ^5.0.0
-    react-is: ^18.0.0
-  checksum: d4b861d5aff94a65ffbf386f312db494f48c9529017e13b2279866fabbd8abdd86acb4e8150d19de07c5d8d46919fcf904e6fa8b034574cdd78bf5f8da0f2ad4
-  languageName: node
-  linkType: hard
-
-"pretty-format@npm:^28.0.2":
+"pretty-format@npm:^28.0.0, pretty-format@npm:^28.0.2":
   version: 28.0.2
   resolution: "pretty-format@npm:28.0.2"
   dependencies:


### PR DESCRIPTION
Fixes #28

~I haven't test~, but seems this is how it works. https://github.com/facebook/jest/blob/bb0956589f9dbddcc13db0f42b2d4d9ff642b2cd/packages/jest-expect/src/index.ts#L35


Tested, it works.