### PR TITLE
Support `snapshotResolver` option

### DIFF
--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -67,8 +67,11 @@ export default async function run({
 
   const { tests, hasFocusedTests } = await loadTests(test.path);
 
+  const snapshotResolver = await snapshot.buildSnapshotResolver(
+    test.context.config
+  );
   const snapshotState = new snapshot.SnapshotState(
-    `${path.dirname(test.path)}/__snapshots__/${path.basename(test.path)}.snap`,
+    snapshotResolver.resolveSnapshotPath(test.path),
     {
       prettierPath: "prettier",
       updateSnapshot,


### PR DESCRIPTION
This minor change adds support for a custom snapshot resolver (the default behavior of the local `__snapshots__` folder is still maintained).