### PR TITLE
Expose jestMock.restoreAllMocks from global setup

### DIFF
--- a/src/global-setup.js
+++ b/src/global-setup.js
@@ -19,4 +19,5 @@ globalThis.jest = {
   spyOn: jestMock.spyOn.bind(jestMock),
   clearAllMocks: jestMock.clearAllMocks.bind(jestMock),
   resetAllMocks: jestMock.resetAllMocks.bind(jestMock),
+  restoreAllMocks: jestMock.restoreAllMocks.bind(jestMock),
 };


### PR DESCRIPTION
We use it to restore all mocked functions in `afterEach`