### PR TITLE
Run `beforeEach`/`afterEach` in the correct order

### DIFF
--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -190,6 +190,10 @@ async function runTest(fn, stats, results, ancestors, name) {
 }
 
 async function runHooks(hook, block, results, stats, ancestors, runInParents) {
+  if (hook.startsWith("before") && block.parent && runInParents) {
+    await runHooks(hook, block.parent, results, stats, ancestors, true);
+  }
+
   for (const { type, fn } of block.hooks) {
     if (type === hook) {
       await callAsync(fn).catch(error => {
@@ -204,7 +208,7 @@ async function runHooks(hook, block, results, stats, ancestors, runInParents) {
     }
   }
 
-  if (block.parent && runInParents) {
+  if (hook.startsWith("after") && block.parent && runInParents) {
     await runHooks(hook, block.parent, results, stats, ancestors, true);
   }
 }


### PR DESCRIPTION
This PR fixes issue #43, it selectively runs the "before" and the "after" hooks separately, before and after the test itself is executed. We've had this running for a while in a medium sized codebase, and it's worked well for us so far!