### PR TITLE
fix: filter tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .pnp.loader.mjs
 .yarn/unplugged
 .yarn/install-state.gz
+
+node_modules

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -117,8 +117,9 @@ async function runTestBlock(
 
     if (
       mode === "skip" ||
-      (hasFocusedTests && type === "test" && mode !== "only") ||
-      shouldSkip(testNamePatternRE, getFullName(nextAncestors))
+      (type === "test" &&
+        ((hasFocusedTests && mode !== "only") ||
+          shouldSkip(testNamePatternRE, getFullName(nextAncestors))))
     ) {
       stats.pending++;
       results.push({ ancestors, title: name, errors: [], skipped: true });


### PR DESCRIPTION
`describeBlock` should not be skipped.

e.g.
`yarn jest babel-cli -t "dir --out-dir --watch multiple dir"`