### PR TITLE
Fix `addSnapshotSerializer`

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,10 +33,10 @@ jobs:
           yarn build
         working-directory: prettier
 
-      - name: Setup Node.js v12
+      - name: Setup Node.js v14
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Run tests
         run: |

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -92,7 +92,11 @@ export default async function run({
   });
   snapshotState.save();
   const snapshotSerializers = snapshot.getSerializers();
-  snapshotSerializers.splice(0, snapshotSerializers.length, ...snapshotSerializersBackup);
+  snapshotSerializers.splice(
+    0,
+    snapshotSerializers.length,
+    ...snapshotSerializersBackup
+  );
 
   return toTestResult(stats, results, test);
 }

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -1,7 +1,7 @@
 import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { performance } from "perf_hooks";
-import snapshot from "jest-snapshot";
+import * as snapshot from "jest-snapshot";
 import { expect } from "expect";
 import * as circus from "jest-circus";
 import { inspect } from "util";
@@ -54,6 +54,7 @@ export default async function run({
   port,
 }) {
   await initialSetup(test.context.config);
+  const snapshotSerializersBackup = [...snapshot.getSerializers()];
 
   port.postMessage("start");
 
@@ -90,6 +91,8 @@ export default async function run({
     frame.file = fileURLToPath(frame.file);
   });
   snapshotState.save();
+  const snapshotSerializers = snapshot.getSerializers();
+  snapshotSerializers.splice(0, snapshotSerializers.length, ...snapshotSerializersBackup);
 
   return toTestResult(stats, results, test);
 }

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -45,6 +45,8 @@ const initialSetup = once(async projectConfig => {
     const { default: setup } = await import(pathToFileURL(setupFile));
     if (typeof setup === "function") await setup();
   }
+
+  return snapshot.getSerializers().slice();
 });
 
 export default async function run({
@@ -53,8 +55,7 @@ export default async function run({
   testNamePattern,
   port,
 }) {
-  await initialSetup(test.context.config);
-  const globalSnapshotSerializers = [...snapshot.getSerializers()];
+  const projectSnapshotSerializers = await initialSetup(test.context.config);
 
   port.postMessage("start");
 
@@ -91,12 +92,10 @@ export default async function run({
     frame.file = fileURLToPath(frame.file);
   });
   snapshotState.save();
-  const snapshotSerializers = snapshot.getSerializers();
-  snapshotSerializers.splice(
-    0,
-    snapshotSerializers.length,
-    ...globalSnapshotSerializers
-  );
+
+  // Restore the project-level serializers, so that serializers
+  // installed by one test file don't leak to other files.
+  arrayReplace(snapshot.getSerializers(), projectSnapshotSerializers);
 
   return toTestResult(stats, results, test);
 }
@@ -312,4 +311,8 @@ function once(fn) {
     result = fn.apply(this, arguments);
     return result;
   };
+}
+
+function arrayReplace(array, replacement) {
+  array.splice(0, array.length, ...replacement);
 }

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -54,7 +54,7 @@ export default async function run({
   port,
 }) {
   await initialSetup(test.context.config);
-  const snapshotSerializersBackup = [...snapshot.getSerializers()];
+  const globalSnapshotSerializers = [...snapshot.getSerializers()];
 
   port.postMessage("start");
 
@@ -95,7 +95,7 @@ export default async function run({
   snapshotSerializers.splice(
     0,
     snapshotSerializers.length,
-    ...snapshotSerializersBackup
+    ...globalSnapshotSerializers
   );
 
   return toTestResult(stats, results, test);


### PR DESCRIPTION
When calling `expect.addSnapshotSerializer` in one test file, the serializer should not be used globally.

Solution verified in https://github.com/prettier/prettier/pull/12859

Fixes #35

