### PR TITLE
Error locations are already converted from URLs to paths by Jest

### DIFF
--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -86,11 +86,6 @@ export default async function run({
   await runTestBlock(tests, hasFocusedTests, testNamePatternRE, results, stats);
   stats.end = performance.now();
 
-  snapshotState._inlineSnapshots.forEach(({ frame }) => {
-    // When using native ESM, errors have a URL location.
-    // Jest expects paths.
-    frame.file = fileURLToPath(frame.file);
-  });
   snapshotState.save();
 
   // Restore the project-level serializers, so that serializers


### PR DESCRIPTION
Fixes https://github.com/babel/babel/pull/14867#issuecomment-1221608605

@fisker Do you use inline snapshots in Prettier, and if yes did you ever had problems with the `-u` Jest options not working?