### PR TITLE
use @jest/expect in worker-runner

### DIFF
--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -1,8 +1,8 @@
 import path from "path";
-import { fileURLToPath, pathToFileURL } from "url";
+import { pathToFileURL } from "url";
 import { performance } from "perf_hooks";
 import * as snapshot from "jest-snapshot";
-import { expect } from "expect";
+import { jestExpect as expect } from "@jest/expect";
 import * as circus from "jest-circus";
 import { inspect } from "util";
 import { isWorkerThread } from "piscina";


### PR DESCRIPTION
The `expect` is not declared in `package.json` anyway. Since we already imported `@jest/expect`, we use `jestExpect` in the worker runner, too.