### PR TITLE
docs(readme): use double quotes for Windows compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ module.exports = {
 You can specify custom ESM loaders using Node.js's [`--loader`](https://nodejs.org/api/cli.html#--loadermodule) option. Jest's CLI doesn't allow providing Node.js-specific options, but you can do it by using the [`NODE_OPTIONS`](https://nodejs.org/docs/latest-v17.x/api/cli.html#node_optionsoptions) environment variable:
 
 ```bash
-NODE_OPTIONS='--loader ts-node/esm' jest
+NODE_OPTIONS="--loader ts-node/esm" jest
 ```
 
 Or, if you are using [`cross-env`](https://www.npmjs.com/package/cross-env) to be able to provide environment variables on multiple OSes:
 
 ```bash
-cross-env NODE_OPTIONS='--loader ts-node/esm' jest
+cross-env NODE_OPTIONS="--loader ts-node/esm" jest
 ```
 
 **Don't** run Node.js directly:


### PR DESCRIPTION
According to the [readme of cross-env](https://github.com/kentcdodds/cross-env/blob/3edefc7b450fe273655664f902fd03d9712177fe/README.md):

> Pay special attention to the **triple backslash** `(\\\)` **before** the **double quotes** `(")` and the **absence** of **single quotes** `(')`. Both of these conditions have to be met in order to work both on Windows and UNIX.

I’ve experienced this on a Window machine before and can confirm that `'` doesn’t work within `cmd.exe`, while `"` does. The former breaks command execution with an error.

As a result, attention is needed when adding a test script to `package.json`, as the double quote needs to be escaped in JSON:

```json
{
  "scripts": {
    "test": "cross-env NODE_OPTIONS=\"--loader ts-node/esm\" jest"
  },
}
```