### PR TITLE
Hide JSON object below stack trace in error

### DIFF
--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -333,7 +333,7 @@ function failureToString(test) {
   return (
     test.ancestors.concat(test.title).join(" > ") +
     "\n" +
-    test.errors.map(error => error.toString().replace(/^/gm, "    ")).join("\n") +
+    test.errors.map(error => error.stack.split('\n').slice(0, -3).join('\n').replace(/^/gm, "    ")).join("\n") +
     "\n"
   );
 }

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -333,7 +333,7 @@ function failureToString(test) {
   return (
     test.ancestors.concat(test.title).join(" > ") +
     "\n" +
-    test.errors.map(error => error.stack.replace(/^/gm, "    ")).join("\n") +
+    test.errors.map(error => error.toString().replace(/^/gm, "    ")).join("\n") +
     "\n"
   );
 }

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -333,7 +333,7 @@ function failureToString(test) {
   return (
     test.ancestors.concat(test.title).join(" > ") +
     "\n" +
-    test.errors.map(error => inspect(error).replace(/^/gm, "    ")).join("\n") +
+    test.errors.map(error => error.stack.replace(/^/gm, "    ")).join("\n") +
     "\n"
   );
 }


### PR DESCRIPTION
There is a lot of unnecessary noise in the error report, which makes it difficult to mentally parse the error message, and there is a lot of scrolling. The whole stack trace and the test result object is written to the console for each error.

This change removes the test result object, because it is already printed properly first, and the last 3 lines of the stack trace, which are usually jest-light-runner internals.

I think it is helpful to keep the stack trace, because you can click on it in vscode to go directly where the error occured. 

```diff
 FAIL  apps/finexa-api/src/debtor/debtors-with-approved-claims/testSum.unit.test.js
  ✕ sum (3 ms)

sum
    JestAssertionError: expect(received).toMatchInlineSnapshot(snapshot)
    
    Snapshot name: `sum 1`
    
    - Snapshot  - 1
    + Received  + 3
    
    - 3
    + {
    +   "result": 2,
    + }
        at /home/zikoat/myrepo/apps/finexa-api/src/debtor/debtors-with-approved-claims/testSum.unit.test.ts:2:29
        at runTest (file:///home/zikoat/myrepo/node_modules/jest-light-runner/src/worker-runner.js:177:3)
-        at runTestBlock (file:///home/zikoat/myrepo/node_modules/jest-light-runner/src/worker-runner.js:141:7)
-        at run (file:///home/zikoat/myrepo/node_modules/jest-light-runner/src/worker-runner.js:86:3)
-        at /home/zikoat/myrepo/node_modules/piscina/src/worker.ts:147:20
-     {
-      matcherResult: {
-        actual: '{\n  "result": 2,\n}',
-        expected: '3',
-        message: '\x1B[2mexpect(\x1B[22m\x1B[38;2;0;95;95m\x1B[48;2;215;255;255mreceived\x1B[49m\x1B[39m\x1B[2m).\x1B[22mtoMatchInlineSnapshot\x1B[2m(\x1B[22m\x1B[38;2;128;0;128m\x1B[48;2;255;215;255msnapshot\x1B[49m\x1B[39m\x1B[2m)\x1B[22m\n' +
-          '\n' +
-          'Snapshot name: `sum 1`\n' +
-          '\n' +
-          '\x1B[38;2;128;0;128m\x1B[48;2;255;215;255m- Snapshot  - 1\x1B[49m\x1B[39m\n' +
-          '\x1B[38;2;0;95;95m\x1B[48;2;215;255;255m+ Received  + 3\x1B[49m\x1B[39m\n' +
-          '\n' +
-          '\x1B[38;2;128;0;128m\x1B[48;2;255;215;255m- 3\x1B[49m\x1B[39m\n' +
-          '\x1B[38;2;0;95;95m\x1B[48;2;215;255;255m+ {\x1B[49m\x1B[39m\n' +
-          '\x1B[38;2;0;95;95m\x1B[48;2;215;255;255m+   "result": 2,\x1B[49m\x1B[39m\n' +
-          '\x1B[38;2;0;95;95m\x1B[48;2;215;255;255m+ }\x1B[49m\x1B[39m',
-        name: 'toMatchInlineSnapshot',
-        pass: false
-      }
-    }

 › 1 snapshot failed.
Snapshot Summary
 › 1 snapshot failed from 1 test suite. Inspect your code changes or run `npm run npx -- -u` to update them.

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   1 failed, 1 total
Time:        0.589 s, estimated 1 s
Ran all test suites matching /testsum/i.
```