### PR TITLE
Avoid late start message after test has finished in `--runInBand` mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,18 @@ export default class LightRunner {
             { transferList: [mc.port1] }
           )
           .then(
-            result => void onResult(test, result),
-            error => void onFailure(test, error)
+            result => {
+              // When `--runInBand` is enabled, `InBandTinypool` executes tasks
+              // in a microtask which may complete prior to having received the
+              // start message on the `MessageChannel`. As such, disconnect the
+              // start callback to avoid late invocations.
+              mc.port2.onmessage = null;
+              onResult(test, result);
+            },
+            error => {
+              mc.port2.onmessage = null;
+              onFailure(test, error);
+            }
           );
       })
     );


### PR DESCRIPTION
The start message that is sent over a test's MessageChannel may arrive after the tests' Promise has already resolved, i.e. the finished callback has already been executed. This results in excessive status message logging, as the late start event does activate the test as "running" even though it has already finished, rendering it in the "running" state forever (and consequently generating excessive status messages as more and more tests become considered "running").

Fixes #76