### PR TITLE
Support snapshot serializer with named export

### DIFF
--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -34,10 +34,10 @@ const initialSetup = once(async projectConfig => {
   for (const snapshotSerializer of projectConfig.snapshotSerializers
     .slice()
     .reverse()) {
-    const { default: serializer } = await import(
+    const module = await import(
       pathToFileURL(snapshotSerializer)
     );
-    snapshot.addSerializer(serializer);
+    snapshot.addSerializer(module.default ?? module);
   }
 
   for (const setupFile of projectConfig.setupFilesAfterEnv) {


### PR DESCRIPTION
Prettier uses a serializer uses named export.

I thought jest doesn't support it before, turns out it's on me...