### PR TITLE
fix: Coverage not accurate on child_process runner

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ const createRunner = ({ runtime = "worker_threads" } = {}) =>
       this._pool = new (runInBand ? InBandTinypool : Tinypool)({
         filename: new URL("./worker-runner.js", import.meta.url).href,
         runtime,
+        minThreads: maxWorkers,
         maxThreads: maxWorkers,
         env,
       });


### PR DESCRIPTION
@fisker You're right, it can destroy processes when idle, which leads to inaccurate coverage.
This PR fixes it, and the tests will be slightly faster. :)