### PR TITLE
Reduce data transferring

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,4 +2,6 @@ compressionLevel: mixed
 
 enableGlobalCache: true
 
+nodeLinker: node-modules
+
 yarnPath: .yarn/releases/yarn-4.0.1.cjs

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ const createRunner = ({ runtime: preferredRuntime = "worker_threads" } = {}) =>
 // rather than worker_threads.
 class MainThreadTinypool {
   _moduleP;
-  _module;
+  _worker;
   _workerData;
   _runTest;
 
@@ -141,7 +141,7 @@ class MainThreadTinypool {
 
     module.setWorkerData(this._workerData);
 
-    this._module = module;
+    this._worker = module;
     this._runTest = module.default;
   }
 
@@ -150,7 +150,7 @@ class MainThreadTinypool {
   }
 
   destroy() {
-    this._module.cleanup();
+    this._worker.cleanup();
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,8 +80,9 @@ const createRunner = ({ runtime: preferredRuntime = "worker_threads" } = {}) =>
 
             for (const listener of listeners) {
               listener({ type: "jest-light-runner-worker-data", workerData });
-              listeners.delete(listener);
             }
+
+            listeners.clear();
           },
         };
         poolRunOption = { channel };

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ const createRunner = ({ runtime: preferredRuntime = "worker_threads" } = {}) =>
         workerData,
       });
 
-      let poolRunOption;
+      let poolRunOptions;
       if (runtime === "child_process") {
         const listeners = new Set();
         const channel = {
@@ -85,7 +85,7 @@ const createRunner = ({ runtime: preferredRuntime = "worker_threads" } = {}) =>
             listeners.clear();
           },
         };
-        poolRunOption = { channel };
+        poolRunOptions = { channel };
       }
 
       await pool.init?.();
@@ -96,7 +96,7 @@ const createRunner = ({ runtime: preferredRuntime = "worker_threads" } = {}) =>
         tests.map(test =>
           mutex(() =>
             onStart(test)
-              .then(() => pool.run(test.path, poolRunOption))
+              .then(() => pool.run(test.path, poolRunOptions))
               .then(result => onResult(test, result))
               .catch(error => onFailure(test, error)),
           ),

--- a/src/index.js
+++ b/src/index.js
@@ -3,18 +3,15 @@ import supportsColor from "supports-color";
 import pLimit from "p-limit";
 
 /** @typedef {import("@jest/test-result").Test} Test */
+/** @typedef {"main_thread" | "worker_threads" | "child_process"} Runtime */
 
-const createRunner = ({ runtime = "worker_threads" } = {}) =>
+const createRunner = ({ runtime: preferredRuntime = "worker_threads" } = {}) =>
   class LightRunner {
     // TODO: Use real private fields when we drop support for Node.js v12
-    _config;
+    _globalConfig;
     _pool;
-    _isProcessRunner = runtime === "child_process";
-    _runInBand = false;
 
-    constructor(config) {
-      this._config = config;
-
+    constructor(globalConfig) {
       // Jest's logic to decide when to spawn workers and when to run in the
       // main thread is quite complex:
       //  https://github.com/facebook/jest/blob/5183c1/packages/jest-core/src/testSchedulerHelper.ts#L13
@@ -24,27 +21,11 @@ const createRunner = ({ runtime = "worker_threads" } = {}) =>
       // when explicitly required, to prevent them from accidentally interfering
       // with the test runner. Jest's default runner does not have this problem
       // because it isolates every test in a vm.Context.
-      const { maxWorkers } = config;
-      const runInBand = maxWorkers === 1;
-      const env =
-        runInBand || this._isProcessRunner
-          ? process.env
-          : {
-              // Workers don't have a tty; we want them to inherit
-              // the color support level from the main thread.
-              FORCE_COLOR: supportsColor.stdout.level,
-              ...process.env,
-            };
+      const runInBand = globalConfig.maxWorkers === 1;
+      const runtime = runInBand ? "main_thread" : preferredRuntime;
 
-      this._runInBand = runInBand;
-      this._pool = new (runInBand ? InBandTinypool : Tinypool)({
-        filename: new URL("./worker-runner.js", import.meta.url).href,
-        runtime,
-        minThreads: maxWorkers,
-        maxThreads: maxWorkers,
-        env,
-        trackUnmanagedFds: false,
-      });
+      this._globalConfig = globalConfig;
+      this._runtime = runtime;
     }
 
     /**
@@ -55,9 +36,58 @@ const createRunner = ({ runtime = "worker_threads" } = {}) =>
      * @param {*} onFailure
      */
     async runTests(tests, watcher, onStart, onResult, onFailure) {
-      const pool = this._pool;
-      const { updateSnapshot, testNamePattern, maxWorkers } = this._config;
-      const isProcessRunner = !this._runInBand && this._isProcessRunner;
+      const projectConfig = tests[0].context.config;
+
+      if (tests.some(test => test.context.config !== projectConfig)) {
+        throw new Error("Unexpected error, all tests should have same config.");
+      }
+
+      const { _runtime: runtime, _globalConfig: globalConfig } = this;
+      const { maxWorkers } = globalConfig;
+      const env =
+        runtime === "worker_threads"
+          ? {
+              // Workers don't have a tty; we want them to inherit
+              // the color support level from the main thread.
+              FORCE_COLOR: supportsColor.stdout.level,
+              ...process.env,
+            }
+          : process.env;
+      const workerData = { globalConfig, projectConfig, runtime };
+      const pool = new (
+        runtime === "main_thread" ? MainThreadTinypool : Tinypool
+      )({
+        filename: new URL("./worker-runner.js", import.meta.url).href,
+        runtime,
+        minThreads: maxWorkers,
+        maxThreads: maxWorkers,
+        env,
+        trackUnmanagedFds: false,
+        workerData,
+      });
+
+      let poolRunOption;
+      if (runtime === "child_process") {
+        const listeners = new Set();
+        const channel = {
+          onMessage(listener) {
+            listeners.add(listener);
+          },
+          postMessage(message) {
+            if (message !== "jest-light-runner-get-worker-data") {
+              return;
+            }
+
+            for (const listener of listeners) {
+              listener({ type: "jest-light-runner-worker-data", workerData });
+              listeners.delete(listener);
+            }
+          },
+        };
+        poolRunOption = { channel };
+      }
+
+      await pool.init?.();
 
       const mutex = pLimit(maxWorkers);
 
@@ -65,14 +95,14 @@ const createRunner = ({ runtime = "worker_threads" } = {}) =>
         tests.map(test =>
           mutex(() =>
             onStart(test)
-              .then(() => pool.run({ test, updateSnapshot, testNamePattern }))
+              .then(() => pool.run(test.path, poolRunOption))
               .then(result => onResult(test, result))
               .catch(error => onFailure(test, error)),
           ),
         ),
       );
 
-      if (isProcessRunner) {
+      if (runtime === "child_process") {
         for (const { process } of pool.threads) {
           // Use `process.disconnect()` instead of `process.kill()`, so we can collect coverage
           // See https://github.com/nicolo-ribaudo/jest-light-runner/issues/90#issuecomment-2812473389
@@ -87,28 +117,40 @@ const createRunner = ({ runtime = "worker_threads" } = {}) =>
             return originalKill.call(process, signal);
           };
         }
-
-        await pool.destroy();
       }
+
+      await pool.destroy();
     }
   };
 
 // Exposes an API similar to Tinypool, but it uses dynamic import()
 // rather than worker_threads.
-class InBandTinypool {
+class MainThreadTinypool {
   _moduleP;
-  _moduleDefault;
+  _module;
+  _workerData;
+  _runTest;
 
-  constructor({ filename }) {
+  constructor({ filename, workerData }) {
     this._moduleP = import(filename);
+    this._workerData = workerData;
+  }
+
+  async init() {
+    const module = await this._moduleP;
+
+    module.setWorkerData(this._workerData);
+
+    this._module = module;
+    this._runTest = module.default;
   }
 
   async run(data) {
-    if (!this._moduleDefault) {
-      this._moduleDefault = (await this._moduleP).default;
-    }
+    return this._runTest(data);
+  }
 
-    return this._moduleDefault(data);
+  destroy() {
+    this._module.cleanup();
   }
 }
 

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -9,21 +9,60 @@ import Tinypool, { workerId } from "tinypool";
 /** @typedef {{ failures: number, passes: number, pending: number, start: number, end: number }} Stats */
 /** @typedef {{ ancestors: string[], title: string, duration: number, errors: Error[], skipped: boolean }} InternalTestResult */
 
-const initialSetup = once(async projectConfig => {
+let workerData = Tinypool.workerData;
+let projectState;
+/**
+ *
+ * @param {{
+ * }} param0
+ * @returns
+ */
+async function initialSetup() {
+  if (!workerData && process.__tinypool_state__?.isChildProcess) {
+    workerData = await new Promise(resolve => {
+      const listener = message => {
+        if (message?.type === "jest-light-runner-worker-data") {
+          process.off("message", listener);
+          resolve(message.workerData);
+        }
+      };
+      process.on("message", listener);
+      process.send("jest-light-runner-get-worker-data");
+    });
+  }
+
+  const { globalConfig, projectConfig, runtime } = workerData;
+
+  const originalDirectory = process.cwd();
+
+  let state = {
+    globalConfig,
+    projectConfig,
+    runtime,
+    JEST_WORKER_ID: process.env.JEST_WORKER_ID,
+    originalDirectory: originalDirectory,
+    originalCwd: process.cwd,
+    originalChdir: process.chdir,
+  };
+
+  // Setup `JEST_WORKER_ID` environment variable
+  // https://jestjs.io/docs/environment-variables
+  if (runtime === "main_thread") {
+    process.env.JEST_WORKER_ID = "1";
+  } else {
+    process.env.JEST_WORKER_ID = String(workerId);
+  }
+
   // Node.js workers (worker_threads) don't support
   // process.chdir, that we use multiple times in our tests.
   // We can "polyfill" it for process.cwd() usage, but it
   // won't affect path.* and fs.* functions.
-  if (Tinypool.isWorkerThread) {
-    process.env.JEST_WORKER_ID = String(workerId);
-    const startCwd = process.cwd();
-    let cwd = startCwd;
-    process.cwd = () => cwd;
-    process.chdir = dir => {
-      cwd = path.resolve(cwd, dir);
+  if (runtime === "worker_threads") {
+    let current = originalDirectory;
+    process.cwd = () => current;
+    process.chdir = directory => {
+      current = path.resolve(current, directory);
     };
-  } else {
-    process.env.JEST_WORKER_ID = "1";
   }
 
   for (const setupFile of projectConfig.setupFiles) {
@@ -48,41 +87,46 @@ const initialSetup = once(async projectConfig => {
     if (typeof setup === "function") await setup();
   }
 
-  return snapshot.getSerializers().slice();
-});
+  state.projectSnapshotSerializers = snapshot.getSerializers().slice();
 
-export default async function run({ test, updateSnapshot, testNamePattern }) {
-  const projectSnapshotSerializers = await initialSetup(test.context.config);
+  return state;
+}
 
-  const testNamePatternRE =
-    testNamePattern != null ? new RegExp(testNamePattern, "i") : null;
+export default async function run(testFilePath) {
+  if (!projectState) {
+    projectState = await initialSetup();
+  }
+
+  const { globalConfig, projectConfig, projectSnapshotSerializers } =
+    projectState;
 
   /** @type {Stats} */
   const stats = { passes: 0, failures: 0, pending: 0, start: 0, end: 0 };
   /** @type {Array<InternalTestResult>} */
   const results = [];
 
-  const { tests, hasFocusedTests } = await loadTests(test.path);
+  const { tests, hasFocusedTests } = await loadTests(testFilePath);
 
-  const snapshotResolver = await snapshot.buildSnapshotResolver(
-    test.context.config,
-  );
+  const snapshotResolver = await snapshot.buildSnapshotResolver(projectConfig);
   const snapshotState = new snapshot.SnapshotState(
-    snapshotResolver.resolveSnapshotPath(test.path),
+    snapshotResolver.resolveSnapshotPath(testFilePath),
     {
       prettierPath: "prettier",
-      updateSnapshot,
-      snapshotFormat: test.context.config.snapshotFormat,
+      updateSnapshot: projectConfig.updateSnapshot,
+      snapshotFormat: projectConfig.snapshotFormat,
     },
   );
-  expect.setState({ snapshotState, testPath: test.path });
+  expect.setState({ snapshotState, testPath: testFilePath });
 
+  const { testNamePattern } = globalConfig;
+  const testNamePatternRE =
+    testNamePattern != null ? new RegExp(testNamePattern, "i") : null;
   stats.start = performance.now();
   await runTestBlock(tests, hasFocusedTests, testNamePatternRE, results, stats);
   stats.end = performance.now();
 
   const result = addSnapshotData(
-    toTestResult(stats, results, test),
+    toTestResult(stats, results, testFilePath, projectConfig),
     snapshotState,
   );
 
@@ -241,10 +285,11 @@ function callAsync(fn) {
  *
  * @param {Stats} stats
  * @param {Array<InternalTestResult>} tests
- * @param {import("@jest/test-result").Test} testInput
+ * @param {string} testFilePath
+ * @param {import("@jest/test-result").Test["context"]["config"]} projectConfig
  * @returns {import("@jest/test-result").TestResult}
  */
-function toTestResult(stats, tests, { path, context }) {
+function toTestResult(stats, tests, testFilePath, projectConfig) {
   const { start, end } = stats;
   const runtime = end - start;
 
@@ -262,7 +307,7 @@ function toTestResult(stats, tests, { path, context }) {
       start,
       end,
       runtime: Math.round(runtime), // ms precision
-      slow: runtime / 1000 > context.config.slowTestThreshold,
+      slow: runtime / 1000 > projectConfig.slowTestThreshold,
     },
     skipped: false,
     snapshot: {
@@ -275,7 +320,7 @@ function toTestResult(stats, tests, { path, context }) {
     },
     sourceMaps: {},
     testExecError: null,
-    testFilePath: path,
+    testFilePath,
     testResults: tests.map(test => {
       return {
         ancestorTitles: test.ancestors,
@@ -339,17 +384,43 @@ function failureToString(test) {
   );
 }
 
-function once(fn) {
-  let called = false;
-  let result;
-  return function () {
-    if (called) return result;
-    called = true;
-    result = fn.apply(this, arguments);
-    return result;
-  };
-}
-
 function arrayReplace(array, replacement) {
   array.splice(0, array.length, ...replacement);
+}
+
+// For MainThreadTinypool to init
+export function setWorkerData(data) {
+  workerData = data;
+}
+
+// For MainThreadTinypool to cleanup
+export async function cleanup() {
+  const { JEST_WORKER_ID, originalDirectory, originalCwd, originalChdir } =
+    projectState;
+
+  // Restore `process.env.JEST_WORKER_ID`
+  if (JEST_WORKER_ID === undefined) {
+    delete process.env.JEST_WORKER_ID;
+  } else {
+    process.env.JEST_WORKER_ID = JEST_WORKER_ID;
+  }
+
+  const currentDirectory = process.cwd();
+
+  if (originalDirectory !== currentDirectory) {
+    process.chdir(originalDirectory);
+  }
+
+  // Restore `process.cwd`
+  if (process.cwd !== originalCwd) {
+    process.cwd = originalCwd;
+  }
+
+  // Restore `process.chdir`
+  if (process.chdir !== originalChdir) {
+    process.chdir = originalChdir;
+  }
+
+  workerData = undefined;
+  projectState = undefined;
 }

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -11,12 +11,7 @@ import Tinypool, { workerId } from "tinypool";
 
 let workerData = Tinypool.workerData;
 let projectState;
-/**
- *
- * @param {{
- * }} param0
- * @returns
- */
+
 async function initialSetup() {
   if (!workerData && process.__tinypool_state__?.isChildProcess) {
     workerData = await new Promise(resolve => {
@@ -47,11 +42,7 @@ async function initialSetup() {
 
   // Setup `JEST_WORKER_ID` environment variable
   // https://jestjs.io/docs/environment-variables
-  if (runtime === "main_thread") {
-    process.env.JEST_WORKER_ID = "1";
-  } else {
-    process.env.JEST_WORKER_ID = String(workerId);
-  }
+  process.env.JEST_WORKER_ID = workerId || 1;
 
   // Node.js workers (worker_threads) don't support
   // process.chdir, that we use multiple times in our tests.
@@ -114,9 +105,7 @@ export default async function run(testFilePath) {
   const stats = { passes: 0, failures: 0, pending: 0, start: 0, end: 0 };
   /** @type {Array<InternalTestResult>} */
   const results = [];
-
   const { tests, hasFocusedTests } = await loadTests(testFilePath);
-
   const snapshotState = new snapshot.SnapshotState(
     snapshotResolver.resolveSnapshotPath(testFilePath),
     {
@@ -394,7 +383,7 @@ function arrayReplace(array, replacement) {
   array.splice(0, array.length, ...replacement);
 }
 
-// For MainThreadTinypool to init
+// For MainThreadTinypool to set worker data
 export function setWorkerData(data) {
   workerData = data;
 }

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -80,7 +80,7 @@ async function initialSetup() {
 
   state.projectSnapshotSerializers = snapshot.getSerializers().slice();
   state.snapshotResolver = await snapshot.buildSnapshotResolver(projectConfig);
-  state.testNamePattern =
+  state.testNamePatternRE =
     globalConfig.testNamePattern !== null
       ? new RegExp(globalConfig.testNamePattern, "i")
       : null;
@@ -94,11 +94,10 @@ export default async function run(testFilePath) {
   }
 
   const {
-    globalConfig,
     projectConfig,
     projectSnapshotSerializers,
     snapshotResolver,
-    testNamePattern,
+    testNamePatternRE,
   } = projectState;
 
   /** @type {Stats} */
@@ -117,7 +116,7 @@ export default async function run(testFilePath) {
   expect.setState({ snapshotState, testPath: testFilePath });
 
   stats.start = performance.now();
-  await runTestBlock(tests, hasFocusedTests, testNamePattern, results, stats);
+  await runTestBlock(tests, hasFocusedTests, testNamePatternRE, results, stats);
   stats.end = performance.now();
 
   const result = addSnapshotData(

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -88,6 +88,7 @@ async function initialSetup() {
   }
 
   state.projectSnapshotSerializers = snapshot.getSerializers().slice();
+  state.snapshotResolver = await snapshot.buildSnapshotResolver(projectConfig);
 
   return state;
 }
@@ -97,8 +98,12 @@ export default async function run(testFilePath) {
     projectState = await initialSetup();
   }
 
-  const { globalConfig, projectConfig, projectSnapshotSerializers } =
-    projectState;
+  const {
+    globalConfig,
+    projectConfig,
+    projectSnapshotSerializers,
+    snapshotResolver,
+  } = projectState;
 
   /** @type {Stats} */
   const stats = { passes: 0, failures: 0, pending: 0, start: 0, end: 0 };
@@ -107,7 +112,6 @@ export default async function run(testFilePath) {
 
   const { tests, hasFocusedTests } = await loadTests(testFilePath);
 
-  const snapshotResolver = await snapshot.buildSnapshotResolver(projectConfig);
   const snapshotState = new snapshot.SnapshotState(
     snapshotResolver.resolveSnapshotPath(testFilePath),
     {

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -89,6 +89,10 @@ async function initialSetup() {
 
   state.projectSnapshotSerializers = snapshot.getSerializers().slice();
   state.snapshotResolver = await snapshot.buildSnapshotResolver(projectConfig);
+  state.testNamePattern =
+    globalConfig.testNamePattern !== null
+      ? new RegExp(globalConfig.testNamePattern, "i")
+      : null;
 
   return state;
 }
@@ -103,6 +107,7 @@ export default async function run(testFilePath) {
     projectConfig,
     projectSnapshotSerializers,
     snapshotResolver,
+    testNamePattern,
   } = projectState;
 
   /** @type {Stats} */
@@ -122,11 +127,8 @@ export default async function run(testFilePath) {
   );
   expect.setState({ snapshotState, testPath: testFilePath });
 
-  const { testNamePattern } = globalConfig;
-  const testNamePatternRE =
-    testNamePattern != null ? new RegExp(testNamePattern, "i") : null;
   stats.start = performance.now();
-  await runTestBlock(tests, hasFocusedTests, testNamePatternRE, results, stats);
+  await runTestBlock(tests, hasFocusedTests, testNamePattern, results, stats);
   stats.end = performance.now();
 
   const result = addSnapshotData(


### PR DESCRIPTION
- Only pass `projectConfig` once
  - in workers use `workerData`
  - in main thread, use named export `setWorkerData`
  - in child process, use `channel`
- Only override `cwd` and `chdir` in worker
- Unset env in main thread