### PR TITLE
Initialize snapshot state before loading tests

### DIFF
--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -105,7 +105,6 @@ export default async function run(testFilePath) {
   const stats = { passes: 0, failures: 0, pending: 0, start: 0, end: 0 };
   /** @type {Array<InternalTestResult>} */
   const results = [];
-  const { tests, hasFocusedTests } = await loadTests(testFilePath);
 
   // https://github.com/jestjs/jest/blob/0c44e271f2e4308c20c81c67e12bacbbb0b2d68f/packages/jest-jasmine2/src/setup_jest_globals.ts#L106C1-L116C6
   const snapshotState = new snapshot.SnapshotState(
@@ -117,6 +116,8 @@ export default async function run(testFilePath) {
     },
   );
   expect.setState({ snapshotState, testPath: testFilePath });
+
+  const { tests, hasFocusedTests } = await loadTests(testFilePath);
 
   stats.start = performance.now();
   await runTestBlock(tests, hasFocusedTests, testNamePatternRE, results, stats);


### PR DESCRIPTION
I'm not sure under which circumstances this exactly goes wrong, but this fixes a difference in behaviour that I observed between the upstream Jest runner and this runner.

A test file that worked with the upstream runner would error out with the following message:

    Snapshot state must be initialized

    Snapshot state has value: undefined

Initializing the snapshot state before loading the tests fixes this.