### PR TITLE
Support `--expand`/`--no-expand` flag

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -71,13 +71,20 @@ jobs:
         with:
           node-version: "14"
 
+      - name: Install yarn@3
+        if: ${{ matrix.node == '14' }}
+        run: |
+          yarn set version 3
+          yarn config set httpRetry 10
+          cat .yarnrc.yml
+
       - name: Run tests on Node.js v14
         if: ${{ matrix.node == '14' }}
         env:
           NODE_ENV: production
           FULL_TEST: true
         run: |
-          npm run test:production-node14 ${{ matrix.additional-options }}
+          yarn test:production-node14 ${{ matrix.additional-options }}
 
   babel:
     name: Babel

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -77,7 +77,7 @@ jobs:
           NODE_ENV: production
           FULL_TEST: true
         run: |
-          node ./node_modules/.bin/jest ${{ matrix.additional-options }}
+          yarn test:node14 ${{ matrix.additional-options }}
 
   babel:
     name: Babel

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -77,7 +77,7 @@ jobs:
           NODE_ENV: production
           FULL_TEST: true
         run: |
-          yarn test:node14 ${{ matrix.additional-options }}
+          npm run test:node14 ${{ matrix.additional-options }}
 
   babel:
     name: Babel

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,16 +61,12 @@ jobs:
       - name: Prepare for Node.js v14
         if: ${{ matrix.node == '14' }}
         run: |
-          node ./scripts/prepare-test-for-legacy-nodejs.js --node-version ${{ matrix.node }}
-          cat package.json
-          yarn
-
-      - name: Install yarn@3
-        if: ${{ matrix.node == '14' }}
-        run: |
           yarn set version 3
           yarn config set httpRetry 10
           cat .yarnrc.yml
+          node ./scripts/prepare-test-for-legacy-nodejs.js --node-version ${{ matrix.node }}
+          cat package.json
+          yarn
 
       - name: Setup Node.js v14
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -65,18 +65,18 @@ jobs:
           cat package.json
           yarn
 
-      - name: Setup Node.js v14
-        uses: actions/setup-node@v4
-        if: ${{ matrix.node == '14' }}
-        with:
-          node-version: "14"
-
       - name: Install yarn@3
         if: ${{ matrix.node == '14' }}
         run: |
           yarn set version 3
           yarn config set httpRetry 10
           cat .yarnrc.yml
+
+      - name: Setup Node.js v14
+        uses: actions/setup-node@v4
+        if: ${{ matrix.node == '14' }}
+        with:
+          node-version: "14"
 
       - name: Run tests on Node.js v14
         if: ${{ matrix.node == '14' }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -77,7 +77,7 @@ jobs:
           NODE_ENV: production
           FULL_TEST: true
         run: |
-          npm run test:node14 ${{ matrix.additional-options }}
+          npm run test:production-node14 ${{ matrix.additional-options }}
 
   babel:
     name: Babel

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The lists below are not comprehensive: feel free to [start a discussion](https:/
 - Jest function mocks: `jest.fn`, `jest.spyOn`, `jest.clearAllMocks`, `jest.resetAllMocks`
 - Jest timer mocks: `jest.useFakeTimers`, `jest.useRealTimers`, `jest.setSystemTime`, `jest.advanceTimersByTime`
 - Inline and external snapshots
-- Jest cli options: `--testNamePattern`/`-t`, `--maxWorkers`, `--runInBand`
+- Jest cli options: `--testNamePattern`/`-t`, `--maxWorkers`, `--runInBand`, `--expand`, `--no-expand`
 - Jest config options: `setupFiles`, `setupFilesAfterEnv`, `snapshotSerializers`, `maxWorkers`, `snapshotFormat`, `snapshotResolver`, `slowTestThreshold`, `prettierPath`, `projects`
 - Jest environment variables: `JEST_WORKER_ID`
 

--- a/src/worker-runner.js
+++ b/src/worker-runner.js
@@ -115,7 +115,11 @@ export default async function run(testFilePath) {
       updateSnapshot: globalConfig.updateSnapshot,
     },
   );
-  expect.setState({ snapshotState, testPath: testFilePath });
+  expect.setState({
+    snapshotState,
+    testPath: testFilePath,
+    expand: globalConfig.expand,
+  });
 
   const { tests, hasFocusedTests } = await loadTests(testFilePath);
 


### PR DESCRIPTION
Prettier have a AST compare test, which assert two big AST objects are equal, without this the diff is huge.

https://github.com/jestjs/jest/blob/905bcbced3d40cdf7aadc4cdf6fb731c4bb3dbe3/packages/expect/src/matchers.ts#L58