### PR TITLE
Use correct Node.js version in tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - ""
+          - "latest"
           - "22"
         additional-options:
           - "--runner jest-light-runner"
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - ""
+          - "latest"
           - "22"
         additional-options:
           - "--runner jest-light-runner"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "latest"
+          - ""
           - "22"
         additional-options:
           - "--runner jest-light-runner"
@@ -45,6 +45,9 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
+        with:
+          check-latest: true
+          node-version: ${{ matrix.node }}
 
       - name: Prepare
         run: |
@@ -63,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "latest"
+          - ""
           - "22"
         additional-options:
           - "--runner jest-light-runner"
@@ -74,8 +77,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: latest
           check-latest: true
+          node-version: ${{ matrix.node }}
 
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - ""
+          - "latest"
           - "22"
         additional-options:
           - "--runner jest-light-runner"
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - ""
+          - "latest"
           - "22"
         additional-options:
           - "--runner jest-light-runner"


### PR DESCRIPTION
Previously, Babel tests all runs on 26, and Prettier tests all runs on 22